### PR TITLE
Feature/add footer

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -105,7 +105,7 @@
                 </tr>
                 <tr>
                     <th>営業時間</th>
-                    <td>7:00~22:00</td>
+                    <td>7:00~22:00（土日祝は20:00まで）</td>
                 </tr>
             </table>
             <p><img src="./assets/cafe.jpg" alt="カフェ外観"></p>

--- a/pages/index.html
+++ b/pages/index.html
@@ -126,5 +126,8 @@
         </form>
     </section>
 </main>
+    <footer>
+        <p>© GitRailway</p>
+    </footer>
 </body>
 </html>

--- a/pages/style.css
+++ b/pages/style.css
@@ -14,3 +14,13 @@
 #top-page-img {
   width: 100%;
 }
+
+footer {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  background-color: #333333;
+  color: white;
+  height: 150px;
+}
+


### PR DESCRIPTION
営業日時の修正

## 背景

もともとは火曜日を定休日、営業時間を7~22時としていたが、土日祝は営業時間を7~20時にしたいと
クライアントから依頼があった。
### 修正前

`<td>7:00~22:00</td>`

### 修正後

`<td>7:00~22:00（土日祝は20:00まで）</td>`
フッターを実装